### PR TITLE
Added check for images with the same name but different extensions

### DIFF
--- a/plugin-build/kmmimages/src/main/kotlin/com/capoax/kmmimages/core/converters/ImageConverter.kt
+++ b/plugin-build/kmmimages/src/main/kotlin/com/capoax/kmmimages/core/converters/ImageConverter.kt
@@ -20,6 +20,14 @@ interface ImageConverter {
         val extension: String = files.first().file.extension
         val absolutePath: String = files.first().file.absolutePath
 
+        /**
+         * Check if all files within the SourceImage are of the same extension
+         */
+        fun isValid(): Boolean {
+            val allFileExtensions = files.map { it.file.extension }.distinct()
+            return allFileExtensions.size == 1
+        }
+
         fun with(imageFile: File, locale: String) = copy(files = files.plus(ImageFile(imageFile, locale)))
     }
 
@@ -30,6 +38,10 @@ interface ImageConverter {
 
     companion object {
         fun convert(imageConverter: ImageConverter, sourceImage: SourceImage, usePdf2SvgTool: Boolean, defaultLanguage: String) {
+            if (!sourceImage.isValid()) {
+                throw IllegalStateException("Multiple images with different extensions found for ${sourceImage.name}, make sure there are no duplicates")
+            }
+
             when (sourceImage.extension) {
                 "png" -> {
                     imageConverter.convertPng(sourceImage, defaultLanguage)


### PR DESCRIPTION
Maybe a nice addition as we encountered this issue in our project.

Currently if there are both a png and a pdf file for an image it will only generate the correct file for the png variant and the pdf file will be added to the Android resources without any conversion. To give a more clear description of what went wrong I added this exception