### PR TITLE
Up kotlin gradle plugin version to 1.7.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.0")
         classpath("com.github.jengelman.gradle.plugins:shadow:2.0.2")
-        classpath(kotlin("gradle-plugin", version = "1.6.0"))
+        classpath(kotlin("gradle-plugin", version = "1.7.21"))
     }
 }
 


### PR DESCRIPTION
I'm using kmm-images library in my own KMM project. I want to update Kotlin version in my project to 1.7 from 1.6. I also want to add support Kotlin 1.7 to this library